### PR TITLE
fix: generate relative css paths that are not wonky

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1045,14 +1045,21 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isexe": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
       "dev": true
+    },
+    "isobject": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
+      "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
+      "requires": {
+        "isarray": "1.0.0"
+      }
     },
     "js-tokens": {
       "version": "4.0.0",
@@ -1659,6 +1666,14 @@
         }
       }
     },
+    "relative": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/relative/-/relative-3.0.2.tgz",
+      "integrity": "sha1-Dc2OxUpdNaPBXhBFA9ZTdbWlNn8=",
+      "requires": {
+        "isobject": "^2.0.0"
+      }
+    },
     "replace-ext": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-1.0.0.tgz",
@@ -2075,11 +2090,6 @@
         "ip-regex": "^4.1.0",
         "tlds": "^1.203.0"
       }
-    },
-    "url-relative": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/url-relative/-/url-relative-1.0.0.tgz",
-      "integrity": "sha1-UlUZZDDnxMImS3cBqpFqtCg3H70="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package.json
+++ b/package.json
@@ -18,8 +18,8 @@
     "rehype-parse": "^6.0.2",
     "rehype-stringify": "^6.0.1",
     "rehype-url-inspector": "^1.0.4",
+    "relative": "^3.0.2",
     "unified": "^8.4.2",
-    "url-relative": "^1.0.0",
     "vfile-find-down": "^5.0.0"
   },
   "devDependencies": {

--- a/process-css.js
+++ b/process-css.js
@@ -1,6 +1,6 @@
 const postcss = require('postcss')
 const url = require('postcss-url')
-const rel = require('url-relative')
+const rel = require('relative')
 const toVfile = require('to-vfile')
 
 const isAbs = /^\/[^/]/


### PR DESCRIPTION
Swap out `url-relative` for `relative` package to fix incorrect relative css path issues.

ref: ipfs/ipfs-docs-v2/pull/46